### PR TITLE
Found another reference mistake

### DIFF
--- a/sigflow.R
+++ b/sigflow.R
@@ -545,7 +545,7 @@ flow_fitting <- function(obj, genome_build, mode, result_dir, nrun = NULL,
   if (genome_build == "hg19") {
     ref_genome <- "BSgenome.Hsapiens.UCSC.hg19"
   } else if (genome_build == "hg38") {
-    ref_genome <- "BSgenome.Hsapiens.UCSC.hg19"
+    ref_genome <- "BSgenome.Hsapiens.UCSC.hg38"
   } else if (genome_build == "mm10") {
     ref_genome <- "BSgenome.Mmusculus.UCSC.mm10"
   }


### PR DESCRIPTION
Found another one! Sorry for the inconvenience. The fitting and extractions pipelines were still not working with hg38 reference MAFs.